### PR TITLE
Improve performance and add ext. properties support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("203")
-        untilBuild.set("222.*")
+        untilBuild.set("223.*")
     }
 
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    version.set("2021.2")
+    version.set("2022.1")
     type.set("IC") // Target IDE Platform
 
     plugins.set(

--- a/src/main/java/com/dengzii/plugin/kt_ext_indexer/ExtMethodListPopup.java
+++ b/src/main/java/com/dengzii/plugin/kt_ext_indexer/ExtMethodListPopup.java
@@ -5,17 +5,16 @@ import com.intellij.openapi.util.NlsContexts;
 import com.intellij.ui.awt.RelativePoint;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.kotlin.psi.KtFunction;
+import org.jetbrains.kotlin.psi.KtCallableDeclaration;
 
 import javax.swing.*;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
 public class ExtMethodListPopup {
-    static void show(List<KtFunction> functions, MouseEvent e) {
-
+    static void show(List<KtCallableDeclaration> declarations, MouseEvent e) {
         final RelativePoint popupPosition = RelativePoint.fromScreen(e.getLocationOnScreen());
-        ListPopupStepImp step = new ListPopupStepImp(functions);
+        ListPopupStepImp step = new ListPopupStepImp(declarations);
         step.selectedListener = ktFunction -> {
             if (ktFunction.canNavigate()) {
                 ktFunction.navigate(true);
@@ -29,28 +28,27 @@ public class ExtMethodListPopup {
         void onSelected(T t);
     }
 
-    static class ListPopupStepImp implements ListPopupStep<KtFunction> {
+    static class ListPopupStepImp implements ListPopupStep<KtCallableDeclaration> {
 
-        List<KtFunction> functions;
-        OnSelectedListener<KtFunction> selectedListener;
+        final List<KtCallableDeclaration> declarations;
+        OnSelectedListener<KtCallableDeclaration> selectedListener;
 
-        public ListPopupStepImp(List<KtFunction> functions) {
-            this.functions = functions;
-//            this.functions.add(null);
+        public ListPopupStepImp(List<KtCallableDeclaration> declarations) {
+            this.declarations = declarations;
         }
 
         @Override
-        public @NotNull List<KtFunction> getValues() {
-            return functions;
+        public @NotNull List<KtCallableDeclaration> getValues() {
+            return declarations;
         }
 
         @Override
-        public boolean isSelectable(KtFunction value) {
+        public boolean isSelectable(KtCallableDeclaration value) {
             return value != null;
         }
 
         @Override
-        public @Nullable Icon getIconFor(KtFunction value) {
+        public @Nullable Icon getIconFor(KtCallableDeclaration value) {
             if (value == null) {
                 return null;
             }
@@ -58,7 +56,7 @@ public class ExtMethodListPopup {
         }
 
         @Override
-        public @NlsContexts.ListItem @NotNull String getTextFor(KtFunction value) {
+        public @NlsContexts.ListItem @NotNull String getTextFor(KtCallableDeclaration value) {
             if (value == null) {
                 return "Non-Project";
             }
@@ -66,7 +64,7 @@ public class ExtMethodListPopup {
         }
 
         @Override
-        public @Nullable ListSeparator getSeparatorAbove(KtFunction value) {
+        public @Nullable ListSeparator getSeparatorAbove(KtCallableDeclaration value) {
             return null;
         }
 
@@ -81,7 +79,7 @@ public class ExtMethodListPopup {
         }
 
         @Override
-        public @Nullable PopupStep<?> onChosen(KtFunction selectedValue, boolean finalChoice) {
+        public @Nullable PopupStep<?> onChosen(KtCallableDeclaration selectedValue, boolean finalChoice) {
             if (selectedValue == null) {
                 return null;
             }
@@ -90,7 +88,7 @@ public class ExtMethodListPopup {
         }
 
         @Override
-        public boolean hasSubstep(KtFunction selectedValue) {
+        public boolean hasSubstep(KtCallableDeclaration selectedValue) {
             return selectedValue == null;
         }
 
@@ -105,7 +103,7 @@ public class ExtMethodListPopup {
         }
 
         @Override
-        public @Nullable MnemonicNavigationFilter<KtFunction> getMnemonicNavigationFilter() {
+        public @Nullable MnemonicNavigationFilter<KtCallableDeclaration> getMnemonicNavigationFilter() {
             return null;
         }
 
@@ -115,7 +113,7 @@ public class ExtMethodListPopup {
         }
 
         @Override
-        public @Nullable SpeedSearchFilter<KtFunction> getSpeedSearchFilter() {
+        public @Nullable SpeedSearchFilter<KtCallableDeclaration> getSpeedSearchFilter() {
             return null;
         }
 

--- a/src/main/java/com/dengzii/plugin/kt_ext_indexer/LineMarkerProviderImpl.java
+++ b/src/main/java/com/dengzii/plugin/kt_ext_indexer/LineMarkerProviderImpl.java
@@ -3,77 +3,89 @@ package com.dengzii.plugin.kt_ext_indexer;
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.codeInsight.daemon.LineMarkerProvider;
-import com.intellij.lang.Language;
 import com.intellij.openapi.editor.markup.GutterIconRenderer;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.ProjectScope;
 import com.intellij.psi.search.searches.ReferencesSearch;
 import com.intellij.util.Query;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.kotlin.psi.KtClass;
-import org.jetbrains.kotlin.psi.KtFunction;
-import org.jetbrains.kotlin.psi.KtNamedFunction;
-import org.jetbrains.kotlin.psi.KtUserType;
+import org.jetbrains.kotlin.idea.stubindex.KotlinSourceFilterScope;
+import org.jetbrains.kotlin.psi.*;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class LineMarkerProviderImpl implements LineMarkerProvider {
     @Override
-    public LineMarkerInfo<?> getLineMarkerInfo(@NotNull PsiElement element) {
-        if (!(element instanceof KtClass) && !(element instanceof PsiClass)) {
-            return null;
-        }
+    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> elements, @NotNull Collection<? super LineMarkerInfo<?>> result) {
+        for (PsiElement element : elements) {
+            if (!(element instanceof KtClassOrObject)) {
+                continue;
+            }
 
-        GlobalSearchScope allScope = ProjectScope.getProjectScope(element.getProject());
-        Query<PsiReference> search = ReferencesSearch.search(element, allScope);
-        for (PsiReference r : search) {
-            KtFunction fun = getKtFunFromPsiReference(r);
-            if (fun != null) {
-                PsiElement nameIdentifier = ((PsiNameIdentifierOwner) element).getNameIdentifier();
-                if (nameIdentifier == null) {
-                    continue;
+            if (element instanceof KtObjectDeclaration && ((KtObjectDeclaration)element).isCompanion()) {
+                continue;
+            }
+
+            Project project = element.getProject();
+            // ext. functions could be declared only in Kotlin sources
+            // TODO: libraries search is out of scope so far
+            GlobalSearchScope projectScope = KotlinSourceFilterScope.projectSources(GlobalSearchScope.projectScope(project), project);
+            Query<PsiReference> search = ReferencesSearch.search(element, projectScope);
+            // no reasons to search for all extension methods/properties to show that
+            // there is at least one ext. function/properties
+            PsiReference reference = search.findFirst();
+            if (reference != null) {
+                KtCallableDeclaration declaration = getKtDeclarationFromPsiReference(reference);
+                if (declaration != null) {
+                    PsiElement nameIdentifier = ((PsiNameIdentifierOwner) element).getNameIdentifier();
+                    if (nameIdentifier == null) {
+                        continue;
+                    }
+                    result.add(new LineMarkerInfo<>(nameIdentifier, nameIdentifier.getTextRange(), ShowExtIcon.icon, null, SHOW_RECEIVERS, GutterIconRenderer.Alignment.LEFT, () -> "extension methods"));
                 }
-                return new LineMarkerInfo<>(nameIdentifier, nameIdentifier.getTextRange(), ShowExtIcon.icon, null, SHOW_RECEIVERS, GutterIconRenderer.Alignment.LEFT, () -> "extension methods");
             }
         }
+    }
+
+    @Override
+    public LineMarkerInfo<?> getLineMarkerInfo(@NotNull PsiElement element) {
         return null;
     }
 
-    private static KtFunction getKtFunFromPsiReference(PsiReference reference) {
-        if (!reference.getElement().getLanguage().is(Language.findLanguageByID("kotlin"))) {
+    private static KtCallableDeclaration getKtDeclarationFromPsiReference(PsiReference reference) {
+        PsiElement element = reference.getElement();
+        if (!(element instanceof KtElement)) {
             return null;
         }
 
-        PsiElement element = reference.getElement();
         PsiElement userType = element.getParent();
         if (!(userType instanceof KtUserType)) {
             return null;
         }
         PsiElement ref = userType.getParent();
 
-        PsiElement fun = ref.getParent();
-        if (!(fun instanceof KtNamedFunction)) {
-            return null;
-        }
-        return (KtNamedFunction) fun;
+        PsiElement parent = ref.getParent();
+        return (parent instanceof KtNamedFunction || parent instanceof KtProperty) ? (KtCallableDeclaration)parent : null;
     }
 
     private static final GutterIconNavigationHandler<PsiElement> SHOW_RECEIVERS = (e, psiElement) -> {
         PsiElement clazz = psiElement.getParent();
 
-        GlobalSearchScope allScope = ProjectScope.getProjectScope(clazz.getProject());
-        Query<PsiReference> search = ReferencesSearch.search(clazz, allScope);
+        GlobalSearchScope projectScope = ProjectScope.getProjectScope(clazz.getProject());
+        Query<PsiReference> search = ReferencesSearch.search(clazz, projectScope);
 
-        List<KtFunction> functions = new ArrayList<>();
-        for (PsiReference r : search) {
-            KtFunction fun = getKtFunFromPsiReference(r);
-            if (fun != null) {
-                functions.add(fun);
+        List<KtCallableDeclaration> declarations = new ArrayList<>();
+        for (PsiReference reference : search) {
+            KtCallableDeclaration declaration = getKtDeclarationFromPsiReference(reference);
+            if (declaration != null) {
+                declarations.add(declaration);
             }
         }
-        ExtMethodListPopup.show(functions, e);
+        ExtMethodListPopup.show(declarations, e);
     };
 
 }


### PR DESCRIPTION
Moved lineMarker calculations to slowPath as it uses ReferencesSearch
Optimize single lineMarker calculation
Add ext. properties support
update plugin until supported IJ version up to 2022.3